### PR TITLE
Use `unsafe_load` instead of `load`

### DIFF
--- a/lib/locode.rb
+++ b/lib/locode.rb
@@ -8,7 +8,7 @@ require_relative 'locode/location'
 module Locode
 
   def self.load_data
-    YAML.load(File.read(File.expand_path('../../data/yaml/dump.yml', __FILE__)))
+    YAML.unsafe_load(File.read(File.expand_path('../../data/yaml/dump.yml', __FILE__)))
   end
   private_class_method :load_data
 


### PR DESCRIPTION
Add psych 4.x support by replacing `YAML.load` with `YAML.unsafe_load` and avoid `Psych::DisallowedClass` error on application initialization.